### PR TITLE
Add Dockerfile, devcontainer.json and amends publish action

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "ss13tools shell",
+	"image": "ghcr.io/riggleprime/ss13tools"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,3 +64,30 @@ jobs:
           generate_release_notes: true
           tag_name: ${{ github.ref }}
           files: SS13Tools.exe
+
+  docker_publish:
+    name: Publish on GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Docker
+        uses: docker/setup-buildx-action@v3
+      - name: Gather Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.action_repository }}
+      - name: Authenticate to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG PYTHON_VERSION=3.11.7
+FROM python:${PYTHON_VERSION} as builder
+
+WORKDIR /app 
+
+COPY . .
+
+RUN pip install --no-cache-dir poetry==1.7.1 && poetry install && poetry build
+
+# 3.18 due to pip being externally managed on 3.19
+FROM alpine:3.18
+
+RUN apk add --no-cache py3-pip
+
+WORKDIR /ss13tools
+
+COPY --from=builder /app/dist/*.whl ./
+
+RUN pip3 install --no-cache-dir *.whl
+
+# Don't use ENTRYPOINT here, so that a different command can be run if desired.
+CMD ["ss13tools"]

--- a/README.md
+++ b/README.md
@@ -12,8 +12,37 @@ Made for Python 3.9+
 
 ## How to run
 
-`pip install ss13-tools; ss13tools` (pip3 on Linux) or dowload the executable [here](https://github.com/RigglePrime/SS13-tools/releases/latest) (Windows only).
+### Github Codespaces
+
+Click the following button to open a codespace with ss13tools in your browser:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/RigglePrime/SS13-tools)
+
+### Windows
+
+Download the executable [here](https://github.com/RigglePrime/SS13-tools/releases/latest)
+
+### pip
+
+`pip install ss13-tools; ss13tools` (or pip3 on some linux distributions)
+
 If the latter is giving you trouble, try the former. Python can be installed [here](https://www.python.org/downloads/)
+
+### Docker
+
+```bash
+docker run --rm -it ghcr.io/riggleprime/ss13tools
+
+# Or to run a specific command (for example, logbuddy)
+
+docker run --rm -it ghcr.io/riggleprime/ss13tools logbuddy
+
+# If you need access to any local files, you'll want to mount a volume as well
+
+docker run --rm -it -v ./directory:/directory ghcr.io/riggleprime/ss13tools logbuddy
+```
+
+Alternatively, you can open the `devcontainer.json` with your code editor of choice, if supported (namely, Visual Studio Code)
 
 Remember, if you ever screw an input up try pressing the up arrow.
 


### PR DESCRIPTION
- Adds a Dockerfile for ss13tools, and makes an action to build and publish it to GHCR
- Adds a `devcontainer.json`, so that it can be launched either by a local code editor, ,or in a Github codespace (or similar) Idea being mainly to let people easily bring up the tools in a browser, though this isn't as user friendly as it could be
- Updates the README accordingly

There's probably better ways to do the 'ss13tools avaliable in a browser' concept, but that's a bit beyond me right now.